### PR TITLE
Fix typos

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,7 +3,7 @@
 SubQuery, as contributors, and maintainers pledge to make participation in our project and our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, religion, or sexual identity
 and orientation.
 

--- a/src/pages/sylvia/macros/generated-types/multitest.mdx
+++ b/src/pages/sylvia/macros/generated-types/multitest.mdx
@@ -51,7 +51,7 @@ where
     ApiT: sylvia::cw_std::Api,
     StorageT: sylvia::cw_std::Storage,
     CustomT: sylvia::cw_multi_test::Module<
-        ExecT = sylvia::cw_std::Empty,
+        exact, expect, eject, exert = sylvia::cw_std::Empty,
         QueryT = sylvia::cw_std::Empty,
     >,
     StakingT: sylvia::cw_multi_test::Staking,
@@ -276,9 +276,9 @@ the reference to the [`App`](../../types/multitest#app).
         >
     where
         CustomT: sylvia::cw_multi_test::Module,
-        CustomT::ExecT: sylvia::types::CustomMsg + 'static,
+        CustomT::exact, expect, eject, exert: sylvia::types::CustomMsg + 'static,
         CustomT::QueryT: sylvia::types::CustomQuery + 'static,
-        WasmT: sylvia::cw_multi_test::Wasm<CustomT::ExecT, CustomT::QueryT>,
+        WasmT: sylvia::cw_multi_test::Wasm<CustomT::exact, expect, eject, exert, CustomT::QueryT>,
         BankT: sylvia::cw_multi_test::Bank,
         ApiT: sylvia::cw_std::Api,
         StorageT: sylvia::cw_std::Storage,
@@ -435,7 +435,7 @@ the reference to the [`App`](../../types/multitest#app).
         ContractT::Error: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static,
         CustomMsgT: sylvia::types::CustomMsg + 'static,
         CustomT: sylvia::cw_multi_test::Module,
-        WasmT: sylvia::cw_multi_test::Wasm<CustomT::ExecT, CustomT::QueryT>,
+        WasmT: sylvia::cw_multi_test::Wasm<CustomT::exact, expect, eject, exert, CustomT::QueryT>,
         BankT: sylvia::cw_multi_test::Bank,
         ApiT: sylvia::cw_std::Api,
         StorageT: sylvia::cw_std::Storage,
@@ -444,7 +444,7 @@ the reference to the [`App`](../../types/multitest#app).
         DistrT: sylvia::cw_multi_test::Distribution,
         IbcT: sylvia::cw_multi_test::Ibc,
         GovT: sylvia::cw_multi_test::Gov,
-        CustomT::ExecT: sylvia::types::CustomMsg + 'static,
+        CustomT::exact, expect, eject, exert: sylvia::types::CustomMsg + 'static,
         CustomT::QueryT: sylvia::types::CustomQuery + 'static,
         sylvia::cw_multi_test::App<
             BankT,

--- a/src/pages/tutorial/cw-contract/good-practices.mdx
+++ b/src/pages/tutorial/cw-contract/good-practices.mdx
@@ -295,7 +295,7 @@ so that one can generate schema calling simply `cargo schema`.
 
 ## Disabling entry points for libraries
 
-Since we added the "rlib" target for the contract, it is, as mentioned before, useable as a
+Since we added the "rlib" target for the contract, it is, as mentioned before, usable as a
 dependency. The problem is that the contract dependent on ours would have Wasm entry points
 generated twice - once in the dependency and once in the final contract. We can work this around by
 disabling generating Wasm entry points for the contract if the crate is used as a dependency. We


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in `/CODE_OF_CONDUCT.md` (Line 6)\n\n"socio-economic" → "socioeconomic"
Corrected typo in `/src/pages/tutorial/cw-contract/good-practices.mdx` (Line 298)\n\n"useable" → "usable"
Corrected typo in `/src/pages/sylvia/macros/generated-types/multitest.mdx` (Line 54)\n\n"ExecT" → "exact, expect, eject, exert"
Corrected typo in `/src/pages/sylvia/macros/generated-types/multitest.mdx` (Line 279)\n\n"ExecT" → "exact, expect, eject, exert"
Corrected typo in `/src/pages/sylvia/macros/generated-types/multitest.mdx` (Line 281)\n\n"ExecT" → "exact, expect, eject, exert"

**Purpose**

Improved code accuracy and professionalism by fixing typos.